### PR TITLE
Update Info.plist

### DIFF
--- a/SwiftAnyPic/Info.plist
+++ b/SwiftAnyPic/Info.plist
@@ -70,8 +70,30 @@
 	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
+	  <key>NSExceptionDomains</key>
+	  <dict>
+	    <key>facebook.com</key>
+	    <dict>
+	      <key>NSIncludesSubdomains</key>
+	      <true/>
+	      <key>NSExceptionRequiresForwardSecrecy</key>
+	      <false/>
+	    </dict>
+	    <key>fbcdn.net</key>
+	    <dict>
+	      <key>NSIncludesSubdomains</key>
+	      <true/>
+	      <key>NSExceptionRequiresForwardSecrecy</key>
+	      <false/>
+	    </dict>
+	    <key>akamaihd.net</key>
+	    <dict>
+	      <key>NSIncludesSubdomains</key>
+	      <true/>
+	      <key>NSExceptionRequiresForwardSecrecy</key>
+	      <false/>
+	    </dict>
+	  </dict>
 	</dict>
 	<key>NSHumanReadableCopyright</key>
 	<string>© 2015 Parse, Inc.</string>


### PR DESCRIPTION
urls that facebook's sdk connects to must be whitelisted in the info.plist with NSAppTransportSecurity
